### PR TITLE
Restructure content into single-page layout

### DIFF
--- a/public_html/index.html
+++ b/public_html/index.html
@@ -28,61 +28,63 @@
 </head>
 <body class="bg-gradient-animation text-gray-100 font-sans">
 
-  <section class="min-h-screen flex flex-col justify-center items-center text-center px-4 fade-in">
-    <h1 class="text-4xl md:text-6xl font-bold text-cyan-400">Rifal Maulana</h1>
-    <p class="mt-4 text-xl">DevOps Engineer & Site Reliability Enthusiast</p>
-    <p class="mt-2 text-gray-400 italic">“Automating everything, monitoring every byte.”</p>
-  </section>
+  <main class="min-h-screen flex flex-col justify-center items-center text-center px-4 space-y-12 fade-in">
+    <header>
+      <h1 class="text-4xl md:text-6xl font-bold text-cyan-400">Rifal Maulana</h1>
+      <p class="mt-4 text-xl">DevOps Engineer & Site Reliability Enthusiast</p>
+      <p class="mt-2 text-gray-400 italic">“Automating everything, monitoring every byte.”</p>
+    </header>
 
-  <section class="max-w-4xl mx-auto mt-12 px-4">
-    <h2 class="text-2xl text-cyan-300 mb-4">Tech Stack</h2>
-    <div class="flex flex-wrap gap-4">
-      <span class="flex items-center gap-2 bg-gray-800 px-3 py-1 rounded">
-        <i class="devicon-docker-plain colored text-2xl"></i>Docker
-      </span>
-      <span class="flex items-center gap-2 bg-gray-800 px-3 py-1 rounded">
-        <i class="devicon-kubernetes-plain colored text-2xl"></i>Kubernetes
-      </span>
-      <span class="flex items-center gap-2 bg-gray-800 px-3 py-1 rounded">
-        <i class="devicon-terraform-plain colored text-2xl"></i>Terraform
-      </span>
-      <span class="flex items-center gap-2 bg-gray-800 px-3 py-1 rounded">
-        <i class="devicon-ansible-plain colored text-2xl"></i>Ansible
-      </span>
-      <span class="flex items-center gap-2 bg-gray-800 px-3 py-1 rounded">
-        <i class="devicon-prometheus-original colored text-2xl"></i>Prometheus
-      </span>
-      <span class="flex items-center gap-2 bg-gray-800 px-3 py-1 rounded">
-        <i class="devicon-grafana-plain colored text-2xl"></i>Grafana
-      </span>
-      <span class="flex items-center gap-2 bg-gray-800 px-3 py-1 rounded">
-        <i class="devicon-linux-plain colored text-2xl"></i>Linux
-      </span>
-      <span class="flex items-center gap-2 bg-gray-800 px-3 py-1 rounded">
-        <i class="devicon-googlecloud-plain colored text-2xl"></i>GCP
-      </span>
-    </div>
-  </section>
+    <section class="max-w-4xl">
+      <h2 class="text-2xl text-cyan-300 mb-4">Tech Stack</h2>
+      <div class="flex flex-wrap justify-center gap-4">
+        <span class="flex items-center gap-2 bg-gray-800 px-3 py-1 rounded">
+          <i class="devicon-docker-plain colored text-2xl"></i>Docker
+        </span>
+        <span class="flex items-center gap-2 bg-gray-800 px-3 py-1 rounded">
+          <i class="devicon-kubernetes-plain colored text-2xl"></i>Kubernetes
+        </span>
+        <span class="flex items-center gap-2 bg-gray-800 px-3 py-1 rounded">
+          <i class="devicon-terraform-plain colored text-2xl"></i>Terraform
+        </span>
+        <span class="flex items-center gap-2 bg-gray-800 px-3 py-1 rounded">
+          <i class="devicon-ansible-plain colored text-2xl"></i>Ansible
+        </span>
+        <span class="flex items-center gap-2 bg-gray-800 px-3 py-1 rounded">
+          <i class="devicon-prometheus-original colored text-2xl"></i>Prometheus
+        </span>
+        <span class="flex items-center gap-2 bg-gray-800 px-3 py-1 rounded">
+          <i class="devicon-grafana-plain colored text-2xl"></i>Grafana
+        </span>
+        <span class="flex items-center gap-2 bg-gray-800 px-3 py-1 rounded">
+          <i class="devicon-linux-plain colored text-2xl"></i>Linux
+        </span>
+        <span class="flex items-center gap-2 bg-gray-800 px-3 py-1 rounded">
+          <i class="devicon-googlecloud-plain colored text-2xl"></i>GCP
+        </span>
+      </div>
+    </section>
 
-  <section class="max-w-4xl mx-auto mt-12 px-4">
-    <h2 class="text-2xl text-cyan-300 mb-4">Featured Projects</h2>
-    <ul class="space-y-4">
-      <li class="bg-gray-800 p-4 rounded">
-        <h3 class="text-xl font-semibold">CI/CD Pipeline GitHub Actions</h3>
-        <p class="text-gray-400">Setup end-to-end CI/CD dengan Docker & GitHub Actions untuk microservices.</p>
-      </li>
-      <li class="bg-gray-800 p-4 rounded">
-        <h3 class="text-xl font-semibold">Kubernetes Cluster + Monitoring</h3>
-        <p class="text-gray-400">Deploy cluster k8s + setup monitoring stack dengan Prometheus & Grafana.</p>
-      </li>
-    </ul>
-  </section>
+    <section class="max-w-4xl">
+      <h2 class="text-2xl text-cyan-300 mb-4">Featured Projects</h2>
+      <ul class="space-y-4 text-left">
+        <li class="bg-gray-800 p-4 rounded">
+          <h3 class="text-xl font-semibold">CI/CD Pipeline GitHub Actions</h3>
+          <p class="text-gray-400">Setup end-to-end CI/CD dengan Docker & GitHub Actions untuk microservices.</p>
+        </li>
+        <li class="bg-gray-800 p-4 rounded">
+          <h3 class="text-xl font-semibold">Kubernetes Cluster + Monitoring</h3>
+          <p class="text-gray-400">Deploy cluster k8s + setup monitoring stack dengan Prometheus & Grafana.</p>
+        </li>
+      </ul>
+    </section>
 
-  <section class="max-w-4xl mx-auto mt-12 px-4 mb-20">
-    <h2 class="text-2xl text-cyan-300 mb-4">Contact</h2>
-    <p>Email: <a href="mailto:rifal@example.com" class="text-cyan-400">rifal@example.com</a></p>
-    <p>GitHub: <a href="https://github.com/altned" class="text-cyan-400">github.com/altned</a></p>
-  </section>
+    <section class="max-w-4xl">
+      <h2 class="text-2xl text-cyan-300 mb-4">Contact</h2>
+      <p>Email: <a href="mailto:rifal@example.com" class="text-cyan-400">rifal@example.com</a></p>
+      <p>GitHub: <a href="https://github.com/altned" class="text-cyan-400">github.com/altned</a></p>
+    </section>
+  </main>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- simplify landing page structure into one cohesive `<main>` container so all sections render on a single page
- center tech stack, project, and contact sections for a compact one-screen layout

## Testing
- `npx htmlhint public_html/index.html` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6892ec27b6c4833188c8b3ec4f583830